### PR TITLE
feat: using k8s-schemas repo to obtain kubernetes schemas

### DIFF
--- a/src/install-dependencies.sh
+++ b/src/install-dependencies.sh
@@ -2,9 +2,9 @@
 
 set -uo errexit
 
-KUBECTL=$1
-printf "Downloading kubectl %s\n" "${KUBECTL}"
-curl -sL https://dl.k8s.io/release/v"${KUBECTL}"/bin/linux/amd64/kubectl \
+KUBERNETES_VERSION=$1
+printf "Downloading kubectl %s\n" "${KUBERNETES_VERSION}"
+curl -sL https://dl.k8s.io/release/v"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl \
 -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 kubectl version --client
 
@@ -88,12 +88,11 @@ wget https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK}/shel
 mv shellcheck-${SHELLCHECK}/shellcheck /usr/local/bin/shellcheck && rm -rf shellcheck-${SHELLCHECK}
 shellcheck --version
 
-printf "\nFetching kubeval kubernetes json schemas for v1.%s.0\n" "$(kubectl version --client=true -o=json | jq -r '.clientVersion.minor' | tr -d '+')"
-mkdir -p /tmp/kubernetes-schemas/v1."$(kubectl version --client=true -o=json | jq -r '.clientVersion.minor' | tr -d '+')".0-standalone-strict
-git clone https://github.com/swade1987/kubernetes-json-schema.git
-# shellcheck disable=SC2046
-cp -R kubernetes-json-schema/v1.$(kubectl version --client=true -o=json | jq -r '.clientVersion.minor' | tr -d '+').0-standalone-strict/* /tmp/kubernetes-schemas/v1.$(kubectl version --client=true -o=json | jq -r '.clientVersion.minor' | tr -d '+').0-standalone-strict
-rm -rf kubernetes-json-schema
+printf "\nFetching kubernetes json schemas for v%s\n" "${KUBERNETES_VERSION}"
+mkdir -p /tmp/kubernetes-schemas/v"${KUBERNETES_VERSION}"-standalone-strict && \
+curl -sL "https://github.com/swade1987/k8s-schemas/releases/download/v${KUBERNETES_VERSION}/kubernetes-json-schema-v${KUBERNETES_VERSION}-standalone-strict.zip" > /tmp/schema.zip && \
+unzip -o /tmp/schema.zip -d /tmp/kubernetes-schemas && \
+rm /tmp/schema.zip
 
 printf "\nFetching flux json schemas for v%s\n" "${FLUX}"
 mkdir -p /tmp/flux-schemas/master-standalone-strict


### PR DESCRIPTION
## Description
Using https://github.com/swade1987/k8s-schemas to obtain Kubernetes schemas

## Motivation and Context
It makes it quicker than downloading the whole repository into the container previously.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
