### PR TITLE
feat: adding automated PRs aligning with k8s releases

### DIFF
--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -37,6 +37,8 @@ jobs:
                     sed 's/^v//' |
                     sort -rV | \
                     head -2)
+          echo "Available versions:"
+          echo "$VERSIONS"
           echo "versions<<EOF" >> "$GITHUB_OUTPUT"
           echo "$VERSIONS" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -46,6 +48,7 @@ jobs:
         run: |
           PR_VERSIONS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading kubernetes to v")) | .title' | \
             grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' || echo "none")
+          echo "Existing PR versions: ${PR_VERSIONS}"
           echo "versions=${PR_VERSIONS}" >> "$GITHUB_OUTPUT"
 
       - name: Process versions
@@ -54,53 +57,26 @@ jobs:
           CURRENT="${{ steps.current.outputs.version }}"
           echo "Current version: $CURRENT"
 
-          # Convert version string to array for proper comparison
-          function version_to_array() {
-            echo "$1" | tr '.' ' '
-          }
-
-          # Compare two version arrays
-          function compare_versions() {
-            read -ra v1 <<< "$(version_to_array "$1")"
-            read -ra v2 <<< "$(version_to_array "$2")"
-
-            for ((i=0; i<${#v1[@]}; i++)); do
-              if ((v1[i] > v2[i])); then
-                echo 1; return
-              elif ((v1[i] < v2[i])); then
-                echo -1; return
-              fi
-            done
-            echo 0
-          }
-
-          # Find next version
-          NEXT_VERSION=""
+          echo "Reading available versions:"
           while IFS= read -r VERSION; do
             [ -z "$VERSION" ] && continue
+            echo "Checking version: $VERSION"
 
-            # Check if this version is newer than current
-            if [ "$(compare_versions "$VERSION" "$CURRENT")" -le 0 ]; then
-              continue
-            fi
+            if [[ "$VERSION" > "$CURRENT" ]]; then
+              # Skip if version has an existing PR
+              if [[ "${{ steps.prs.outputs.versions }}" != "none" ]] && \
+                 echo "${{ steps.prs.outputs.versions }}" | grep -q "^${VERSION}$"; then
+                echo "Version ${VERSION} already has an open PR"
+                continue
+              fi
 
-            # Skip if version has an existing PR
-            if [[ "${{ steps.prs.outputs.versions }}" != "none" ]] && \
-               echo "${{ steps.prs.outputs.versions }}" | grep -q "^${VERSION}$"; then
-              echo "Version ${VERSION} already has an open PR"
-              continue
-            fi
-
-            # If we haven't set a next version yet, or if this version is older than our current next version
-            if [ -z "$NEXT_VERSION" ] || [ "$(compare_versions "$VERSION" "$NEXT_VERSION")" -lt 0 ]; then
-              NEXT_VERSION="$VERSION"
+              echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+              echo "Found new version to update to: ${VERSION}"
+              break
+            else
+              echo "Version ${VERSION} is not newer than ${CURRENT}"
             fi
           done <<< "${{ steps.versions.outputs.versions }}"
-
-          if [ -n "$NEXT_VERSION" ]; then
-            echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "Found new version to update to: ${NEXT_VERSION}"
-          fi
 
       - name: Configure Git
         if: steps.process.outputs.version != ''

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -31,13 +31,12 @@ jobs:
       - name: Get latest K8s versions
         id: latest
         run: |
-          # Get versions and sort them in ascending order (oldest first)
-          VERSIONS=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases | \
-            jq -r '.[].tag_name' | \
-            grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | \
-            sed 's/^v//' | \
-            sort -V | \  # Changed from sort -rV to sort -V
-            head -5)     # Get more versions to ensure we don't miss intermediates
+          VERSIONS=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases |
+                    jq -r '.[].tag_name' |
+                    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+                    sed 's/^v//' |
+                    sort -rV | \
+                    head -2)
           echo "versions<<EOF" >> "$GITHUB_OUTPUT"
           echo "$VERSIONS" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -28,20 +28,18 @@ jobs:
           CURRENT_VERSION=$(grep 'KUBERNETES_VERSION :=' Makefile | awk '{print $3}')
           echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Get latest K8s versions
-        id: latest
+      - name: Get K8s versions
+        id: versions
         run: |
-          VERSIONS=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases |
-                    jq -r '.[].tag_name' |
-                    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
-                    sed 's/^v//' |
-                    sort -rV | \
-                    head -2)
+          # Get and sort versions
+          curl -s https://api.github.com/repos/kubernetes/kubernetes/releases |
+          jq -r '.[].tag_name' |
+          grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+          sed 's/^v//' |
+          sort -V > $GITHUB_WORKSPACE/k8s_versions.txt
+
           echo "Available versions:"
-          echo "$VERSIONS"
-          echo "versions<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$VERSIONS" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          cat $GITHUB_WORKSPACE/k8s_versions.txt
 
       - name: Get existing PRs
         id: prs
@@ -74,7 +72,7 @@ jobs:
             else
               echo "Version ${VERSION} is not newer than ${CURRENT}"
             fi
-          done < versions.txt
+          done < $GITHUB_WORKSPACE/k8s_versions.txt
 
       - name: Configure Git
         if: steps.process.outputs.version != ''

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -1,0 +1,88 @@
+name: Monitor Kubernetes Versions
+
+on:
+  pull_request:
+
+#on:
+#  schedule:
+#    - cron: '0 0 * * *'  # Run daily at midnight
+#  workflow_dispatch:  # Allow manual triggers
+
+jobs:
+  check-k8s-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Get current and available K8s versions
+        id: versions
+        run: |
+          # Get current version from Makefile
+          CURRENT_VERSION=$(grep 'KUBERNETES_VERSION :=' Makefile | awk '{print $3}')
+          echo "current=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+          # Get all recent stable K8s versions
+          VERSIONS=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases | \
+            jq -r '.[].tag_name' | \
+            grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | \
+            sed 's/^v//' | \
+            sort -rV | \
+            head -2)  # Get top 2 versions
+          echo "versions=${VERSIONS}" >> $GITHUB_OUTPUT
+
+          # Get versions from existing PRs
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("updating kubernetes to v")) | .title' | \
+            grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          echo "existing_prs=${EXISTING_PRS:-none}" >> $GITHUB_OUTPUT
+
+      - name: Process versions
+        id: process
+        run: |
+          CURRENT_VERSION="${{ steps.versions.outputs.current }}"
+          EXISTING_PRS="${{ steps.versions.outputs.existing_prs }}"
+
+          # Convert newline-separated versions to array
+          IFS=$'\n' read -r -d '' -a ALL_VERSIONS <<< "${{ steps.versions.outputs.versions }}"
+
+          for VERSION in "${ALL_VERSIONS[@]}"; do
+            # Skip if version is already in a PR
+            if [[ "${EXISTING_PRS}" != "none" ]] && echo "${EXISTING_PRS}" | grep -q "^${VERSION}$"; then
+              echo "Version ${VERSION} already has an open PR"
+              continue
+            fi
+
+            # Skip if version is older or equal to current version
+            if [[ "$(echo -e "${VERSION}\n${CURRENT_VERSION}" | sort -V | tail -n1)" == "${CURRENT_VERSION}" ]]; then
+              echo "Version ${VERSION} is not newer than current version ${CURRENT_VERSION}"
+              continue
+            fi
+
+            # Found a version to update to
+            echo "version_to_update=${VERSION}" >> $GITHUB_OUTPUT
+            break
+          done
+
+      - name: Configure Git
+        if: steps.process.outputs.version_to_update != ''
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Run upgrade script
+        if: steps.process.outputs.version_to_update != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-k8s.sh
+          ./scripts/upgrade-k8s.sh --execute ${{ steps.process.outputs.version_to_update }}

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -1,12 +1,9 @@
 name: Monitor Kubernetes Versions
 
 on:
-  pull_request:
-
-#on:
-#  schedule:
-#    - cron: '0 0 * * *'  # Run daily at midnight
-#  workflow_dispatch:  # Allow manual triggers
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight
+  workflow_dispatch:  # Allow manual triggers
 
 jobs:
   check-k8s-version:

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -25,64 +25,70 @@ jobs:
         run: |
           gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Get current and available K8s versions
-        id: versions
+      - name: Get current version
+        id: current
         run: |
-          # Get current version from Makefile
           CURRENT_VERSION=$(grep 'KUBERNETES_VERSION :=' Makefile | awk '{print $3}')
-          echo "current=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
 
-          # Get all recent stable K8s versions
+      - name: Get latest K8s versions
+        id: latest
+        run: |
           VERSIONS=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases | \
             jq -r '.[].tag_name' | \
             grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | \
             sed 's/^v//' | \
             sort -rV | \
-            head -2)  # Get top 2 versions
-          echo "versions=${VERSIONS}" >> $GITHUB_OUTPUT
+            head -2)
+          echo "versions<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$VERSIONS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
-          # Get versions from existing PRs
-          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("updating kubernetes to v")) | .title' | \
-            grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
-          echo "existing_prs=${EXISTING_PRS:-none}" >> $GITHUB_OUTPUT
+      - name: Get existing PRs
+        id: prs
+        run: |
+          PR_VERSIONS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading kubernetes to v")) | .title' | \
+            grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' || echo "none")
+          echo "versions=${PR_VERSIONS}" >> "$GITHUB_OUTPUT"
 
       - name: Process versions
         id: process
         run: |
-          CURRENT_VERSION="${{ steps.versions.outputs.current }}"
-          EXISTING_PRS="${{ steps.versions.outputs.existing_prs }}"
+          CURRENT="${{ steps.current.outputs.version }}"
+          echo "Current version: $CURRENT"
 
-          # Convert newline-separated versions to array
-          IFS=$'\n' read -r -d '' -a ALL_VERSIONS <<< "${{ steps.versions.outputs.versions }}"
+          while IFS= read -r VERSION; do
+            # Skip empty lines
+            [ -z "$VERSION" ] && continue
 
-          for VERSION in "${ALL_VERSIONS[@]}"; do
-            # Skip if version is already in a PR
-            if [[ "${EXISTING_PRS}" != "none" ]] && echo "${EXISTING_PRS}" | grep -q "^${VERSION}$"; then
+            # Skip if version has an existing PR
+            if [[ "${{ steps.prs.outputs.versions }}" != "none" ]] && \
+               echo "${{ steps.prs.outputs.versions }}" | grep -q "^${VERSION}$"; then
               echo "Version ${VERSION} already has an open PR"
               continue
             fi
 
-            # Skip if version is older or equal to current version
-            if [[ "$(echo -e "${VERSION}\n${CURRENT_VERSION}" | sort -V | tail -n1)" == "${CURRENT_VERSION}" ]]; then
-              echo "Version ${VERSION} is not newer than current version ${CURRENT_VERSION}"
+            # Skip if version is not newer
+            if ! [[ "${VERSION}" > "${CURRENT}" ]]; then
+              echo "Version ${VERSION} is not newer than ${CURRENT}"
               continue
             fi
 
-            # Found a version to update to
-            echo "version_to_update=${VERSION}" >> $GITHUB_OUTPUT
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "Found new version to update to: ${VERSION}"
             break
-          done
+          done <<< "${{ steps.latest.outputs.versions }}"
 
       - name: Configure Git
-        if: steps.process.outputs.version_to_update != ''
+        if: steps.process.outputs.version != ''
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Run upgrade script
-        if: steps.process.outputs.version_to_update != ''
+        if: steps.process.outputs.version != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod +x ./scripts/upgrade-k8s.sh
-          ./scripts/upgrade-k8s.sh --execute ${{ steps.process.outputs.version_to_update }}
+          ./scripts/upgrade-k8s.sh --execute ${{ steps.process.outputs.version }}

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -16,11 +16,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup GitHub CLI
         run: |
-          gh auth login --with-token <<< "${{ secrets.PAT_GITHUB_TOKEN }}"
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
 
       - name: Get current version
         id: current

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -74,6 +74,9 @@ jobs:
             fi
           done < $GITHUB_WORKSPACE/k8s_versions.txt
 
+          # Clean up temporary file
+          rm $GITHUB_WORKSPACE/k8s_versions.txt
+
       - name: Configure Git
         if: steps.process.outputs.version != ''
         run: |

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -8,22 +8,25 @@ on:
 #    - cron: '0 0 * * *'  # Run daily at midnight
 #  workflow_dispatch:  # Allow manual triggers
 
+name: Monitor Kubernetes Versions
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
 jobs:
   check-k8s-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_GITHUB_TOKEN }}
 
       - name: Setup GitHub CLI
         run: |
-          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+          gh auth login --with-token <<< "${{ secrets.PAT_GITHUB_TOKEN }}"
 
       - name: Get current version
         id: current
@@ -34,12 +37,13 @@ jobs:
       - name: Get latest K8s versions
         id: latest
         run: |
+          # Get versions and sort them in ascending order (oldest first)
           VERSIONS=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases | \
             jq -r '.[].tag_name' | \
             grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | \
             sed 's/^v//' | \
-            sort -rV | \
-            head -2)
+            sort -V | \  # Changed from sort -rV to sort -V
+            head -5)     # Get more versions to ensure we don't miss intermediates
           echo "versions<<EOF" >> "$GITHUB_OUTPUT"
           echo "$VERSIONS" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -57,9 +61,20 @@ jobs:
           CURRENT="${{ steps.current.outputs.version }}"
           echo "Current version: $CURRENT"
 
+          # Read versions into array and sort them
+          VERSIONS_ARRAY=()
           while IFS= read -r VERSION; do
-            # Skip empty lines
             [ -z "$VERSION" ] && continue
+            VERSIONS_ARRAY+=("$VERSION")
+          done <<< "${{ steps.latest.outputs.versions }}"
+
+          # Process versions in ascending order
+          for VERSION in "${VERSIONS_ARRAY[@]}"; do
+            # Skip if not newer than current
+            if ! [[ "${VERSION}" > "${CURRENT}" ]]; then
+              echo "Version ${VERSION} is not newer than ${CURRENT}"
+              continue
+            fi
 
             # Skip if version has an existing PR
             if [[ "${{ steps.prs.outputs.versions }}" != "none" ]] && \
@@ -68,27 +83,22 @@ jobs:
               continue
             fi
 
-            # Skip if version is not newer
-            if ! [[ "${VERSION}" > "${CURRENT}" ]]; then
-              echo "Version ${VERSION} is not newer than ${CURRENT}"
-              continue
-            fi
-
+            # Found the next version to update to
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "Found new version to update to: ${VERSION}"
             break
-          done <<< "${{ steps.latest.outputs.versions }}"
+          done
 
       - name: Configure Git
         if: steps.process.outputs.version != ''
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
 
       - name: Run upgrade script
         if: steps.process.outputs.version != ''
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           chmod +x ./scripts/upgrade-k8s.sh
           ./scripts/upgrade-k8s.sh --execute ${{ steps.process.outputs.version }}

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -54,18 +54,33 @@ jobs:
           CURRENT="${{ steps.current.outputs.version }}"
           echo "Current version: $CURRENT"
 
-          # Read versions into array and sort them
-          VERSIONS_ARRAY=()
+          # Convert version string to array for proper comparison
+          function version_to_array() {
+            echo "$1" | tr '.' ' '
+          }
+
+          # Compare two version arrays
+          function compare_versions() {
+            read -ra v1 <<< "$(version_to_array "$1")"
+            read -ra v2 <<< "$(version_to_array "$2")"
+
+            for ((i=0; i<${#v1[@]}; i++)); do
+              if ((v1[i] > v2[i])); then
+                echo 1; return
+              elif ((v1[i] < v2[i])); then
+                echo -1; return
+              fi
+            done
+            echo 0
+          }
+
+          # Find next version
+          NEXT_VERSION=""
           while IFS= read -r VERSION; do
             [ -z "$VERSION" ] && continue
-            VERSIONS_ARRAY+=("$VERSION")
-          done <<< "${{ steps.latest.outputs.versions }}"
 
-          # Process versions in ascending order
-          for VERSION in "${VERSIONS_ARRAY[@]}"; do
-            # Skip if not newer than current
-            if ! [[ "${VERSION}" > "${CURRENT}" ]]; then
-              echo "Version ${VERSION} is not newer than ${CURRENT}"
+            # Check if this version is newer than current
+            if [ "$(compare_versions "$VERSION" "$CURRENT")" -le 0 ]; then
               continue
             fi
 
@@ -76,11 +91,16 @@ jobs:
               continue
             fi
 
-            # Found the next version to update to
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "Found new version to update to: ${VERSION}"
-            break
-          done
+            # If we haven't set a next version yet, or if this version is older than our current next version
+            if [ -z "$NEXT_VERSION" ] || [ "$(compare_versions "$VERSION" "$NEXT_VERSION")" -lt 0 ]; then
+              NEXT_VERSION="$VERSION"
+            fi
+          done <<< "${{ steps.versions.outputs.versions }}"
+
+          if [ -n "$NEXT_VERSION" ]; then
+            echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "Found new version to update to: ${NEXT_VERSION}"
+          fi
 
       - name: Configure Git
         if: steps.process.outputs.version != ''

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -8,12 +8,6 @@ on:
 #    - cron: '0 0 * * *'  # Run daily at midnight
 #  workflow_dispatch:  # Allow manual triggers
 
-name: Monitor Kubernetes Versions
-on:
-  schedule:
-    - cron: '0 0 * * *'
-  workflow_dispatch:
-
 jobs:
   check-k8s-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -59,11 +59,9 @@ jobs:
 
           echo "Reading available versions:"
           while IFS= read -r VERSION; do
-            [ -z "$VERSION" ] && continue
             echo "Checking version: $VERSION"
 
             if [[ "$VERSION" > "$CURRENT" ]]; then
-              # Skip if version has an existing PR
               if [[ "${{ steps.prs.outputs.versions }}" != "none" ]] && \
                  echo "${{ steps.prs.outputs.versions }}" | grep -q "^${VERSION}$"; then
                 echo "Version ${VERSION} already has an open PR"
@@ -76,7 +74,7 @@ jobs:
             else
               echo "Version ${VERSION} is not newer than ${CURRENT}"
             fi
-          done <<< "${{ steps.versions.outputs.versions }}"
+          done < versions.txt
 
       - name: Configure Git
         if: steps.process.outputs.version != ''


### PR DESCRIPTION
## Motivation and Context
I want to automate the creation of new images when new Kubernetes releases are cut

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
