### PR TITLE
feat: upgrade to flux v2.5.0 (including dependencies)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.2
+FROM alpine:3.21.3
 LABEL MAINTAINER="Steven Wade <steven@stevenwade.co.uk>"
 
 ARG KUBERNETES_VERSION="Unknown"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Images can be found at [https://eu.gcr.io/swade1987/kubernetes-toolkit](https://
 
 ### Core Kubernetes Tools
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/) (version passed as build argument)
-- [kustomize](https://github.com/kubernetes-sigs/kustomize) (v5.4.3)
-- [Helm v3](https://github.com/helm/helm) (v3.16.1)
+- [kustomize](https://github.com/kubernetes-sigs/kustomize) (v5.6.0)
+- [Helm v3](https://github.com/helm/helm) (v3.17.1)
 - [helm-docs](https://github.com/norwoodj/helm-docs)  (v1.14.2)
 
 ### Validation & Testing

--- a/src/install-dependencies.sh
+++ b/src/install-dependencies.sh
@@ -8,13 +8,13 @@ curl -sL https://dl.k8s.io/release/v"${KUBERNETES_VERSION}"/bin/linux/amd64/kube
 -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 kubectl version --client
 
-KUSTOMIZE=5.4.3
+KUSTOMIZE=5.6.0
 printf "\nDownloading kustomize %s\n" "${KUSTOMIZE}"
 curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE}/kustomize_v${KUSTOMIZE}_linux_amd64.tar.gz | \
 tar xz && mv kustomize /usr/local/bin/kustomize
 kustomize version
 
-HELM_V3=3.16.1
+HELM_V3=3.17.1
 printf "\nDownloading helm %s\n" "${HELM_V3}"
 curl -sSL https://get.helm.sh/helm-v${HELM_V3}-linux-amd64.tar.gz | \
 tar xz && mv linux-amd64/helm /usr/local/bin/helmv3 && rm -rf linux-amd64 && ln -s /usr/local/bin/helmv3 /usr/local/bin/helm
@@ -33,7 +33,7 @@ curl -sL https://github.com/open-policy-agent/conftest/releases/download/v${CONF
 tar xz && mv conftest /usr/local/bin/conftest
 conftest --version
 
-FLUX=2.3.0
+FLUX=2.5.0
 printf "\nDownloading flux %s\n" "${FLUX}"
 curl -sL https://github.com/fluxcd/flux2/releases/download/v${FLUX}/flux_${FLUX}_linux_amd64.tar.gz | \
 tar xz && mv flux /usr/local/bin/flux


### PR DESCRIPTION
## Description
Upgrades to the latest flux2 release ([v.2.5.0](https://github.com/fluxcd/flux2/releases/tag/v2.5.0))

It also updates the kustomize and helm versions to those leveraged by flux.

- [helm controller release notes](https://github.com/fluxcd/helm-controller/blob/v1.2.0/CHANGELOG.md#120)
- [kustomize controller release notes](https://github.com/fluxcd/kustomize-controller/blob/v1.5.0/CHANGELOG.md#150)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
