### PR TITLE
ci: bring repo up to podium's OpenSSF/SLSA standard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Names the repo owner for GitHub's own UI (review requests, blame).
+# The branch ruleset does not require owner review before merge — this
+# file's effect is currently informational only.
+* @swade1987

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -1,7 +1,7 @@
 name: commit-lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -16,5 +16,7 @@ jobs:
     name: commit-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: wagoid/commitlint-github-action@3d28780bbf0365e29b144e272b2121204d5be5f3 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -8,24 +8,38 @@ on:
 env:
   KUBERNETES_VERSION: 1.37.0
 
+concurrency:
+  group: image-${{ github.ref }}
+  cancel-in-progress: true
+
+# Safe floor for any job that doesn't declare its own permissions; the
+# build job below still needs and declares its own broader grants.
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.3.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to GCR
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: eu.gcr.io
           username: _json_key
@@ -37,10 +51,11 @@ jobs:
           # Remove 'v' prefix if present
           VERSION=${GITHUB_REF#refs/tags/v}
           VERSION=${VERSION#refs/tags/}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Build and push
-        uses: docker/build-push-action@v6.13.0
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           build-args: |
             KUBERNETES_VERSION=${{ env.KUBERNETES_VERSION }}
@@ -49,3 +64,31 @@ jobs:
           tags: |
             eu.gcr.io/swade1987/kubernetes-toolkit:latest
             eu.gcr.io/swade1987/kubernetes-toolkit:${{ env.VERSION }}
+
+      # Signed SLSA build provenance, verifiable with "gh attestation verify".
+      # push-to-registry is left off: GCR's OCI-referrer support for a
+      # Sigstore-format attestation isn't confirmed, and the attestation is
+      # already verifiable via GitHub's own attestation store either way.
+      - name: Attest build provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: eu.gcr.io/swade1987/kubernetes-toolkit
+          subject-digest: ${{ steps.push.outputs.digest }}
+
+      # SPDX SBOM for the exact image just pushed (pinned to its digest, not
+      # a floating tag), attested alongside the provenance.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          image: eu.gcr.io/swade1987/kubernetes-toolkit@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: eu.gcr.io/swade1987/kubernetes-toolkit
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: sbom.spdx.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: lint
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: hadolint/hadolint-action@06be81baf89a55ffd0e24b8f04a4185738dd3387 # v3.5.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: error
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          severity: error

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: pr-lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -16,6 +16,6 @@ jobs:
     name: pr-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,23 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: setup node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
+      # Pinned to the current v4 line rather than the newer v6 major - this
+      # step is the live release automation for the whole repo, and a major
+      # bump here isn't verified compatible. Let Dependabot open that as its
+      # own reviewable PR instead of bundling it into a CI-hardening change.
       - name: release
         id: release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4 # v4.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: Scorecard analysis workflow
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+    - main
+  schedule:
+    # Weekly on Saturdays.
+    - cron:  '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          # And it's free for you!
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,13 @@ on:
 env:
   KUBERNETES_VERSION: 1.37.0
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,19 +20,19 @@ jobs:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Login to GCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: eu.gcr.io
           username: _json_key
           password: ${{ secrets.PUBLIC_GCR_JSON_KEY }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           build-args: |
             KUBERNETES_VERSION=${{ env.KUBERNETES_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 LABEL MAINTAINER="Steven Wade <steven@stevenwade.co.uk>"
 
 ARG KUBERNETES_VERSION="Unknown"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported versions
+
+kubernetes-toolkit ships one rolling `latest` image, tagged per release; there's no long-term-support branch to track. Security fixes land on `main` and are published as the next tagged release.
+
+## Reporting a vulnerability
+
+Please report security issues privately rather than opening a public GitHub issue: use [GitHub's private vulnerability reporting](https://github.com/swade1987/kubernetes-toolkit/security/advisories/new) for this repository (Security tab → Report a vulnerability).
+
+Include what you'd include in any good bug report: the affected version or commit, what you found, and how to reproduce it. We'll acknowledge new reports within 5 business days and aim to have a fix or mitigation plan within 30 days, depending on severity.
+
+## Scope
+
+The image bundles third-party Kubernetes tooling (kubectl, helm, and others) at pinned versions; a vulnerability in one of those tools upstream is best reported to that project directly, but a report that the image is shipping a version with a known, fixed CVE is in scope here. Reports about the image build, install scripts, or the CI/release pipeline are also in scope.


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary
- Switches `commit-lint` and `pr-lint` off `pull_request_target` onto plain `pull_request` — the former is the dangerous-workflow pattern OpenSSF Scorecard flags, and neither action needed the elevated trust.
- Pins every GitHub Action to an exact commit SHA (upgraded to each action's current latest release while at it, except `cycjimmy/semantic-release-action`, deliberately left on its current v4 line — see that commit's message) and adds explicit least-privilege `permissions:` blocks to `image.yml` and `test.yml`.
- Pins the `alpine:3.23.3` base image by digest.
- Adds signed SLSA build provenance and an attested SPDX SBOM for every published image (`actions/attest`), verifiable with `gh attestation verify`. `push-to-registry` is left off since GCR's OCI-referrer support isn't confirmed; the attestation is verifiable via GitHub's own store regardless.
- Adds a `lint.yml` (hadolint + shellcheck), a Scorecard analysis workflow, `.github/dependabot.yml` (github-actions + docker), `SECURITY.md`, and `.github/CODEOWNERS` — all mirroring what's already live on `platformfix/podium`.

## Test plan
- [x] `hadolint Dockerfile` — no `error`-severity findings (pre-existing style/warning findings only, below the workflow's failure threshold)
- [x] `shellcheck --severity=error` on all three scripts — clean
- [x] Every changed/new workflow YAML parses (`yq eval`)
- [x] Every action SHA resolved live via `gh api .../git/refs/tags/...` (peeling annotated tag objects where needed), not guessed
- [x] Branched from current `origin/main` (local `main` had diverged) so `KUBERNETES_VERSION` stays at the real current value (1.37.0), not stale