### PR TITLE
ci: fix Dependabot PR checks and harden the version-monitor workflow

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -14,6 +14,11 @@ permissions:
 jobs:
   commit-lint:
     name: commit-lint
+    # Dependabot's own commit messages (e.g. "Bump alpine from 3.23.3 to
+    # 3.24.1") fail subject-case regardless of how conventional its PR
+    # titles are - those are linted separately by pr-lint, and the squash
+    # merge uses the PR title/body, not the raw commit message.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/monitor-k8s-versions.yml
+++ b/.github/workflows/monitor-k8s-versions.yml
@@ -5,12 +5,16 @@ on:
     - cron: '0 0 * * *'  # Run daily at midnight
   workflow_dispatch:  # Allow manual triggers
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-k8s-version:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,11 @@ jobs:
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-      - name: Login to GCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: eu.gcr.io
-          username: _json_key
-          password: ${{ secrets.PUBLIC_GCR_JSON_KEY }}
-      - name: Build and push
+      # No registry login here: this build never pushes (push: false below),
+      # so it needs no credentials - and Dependabot-triggered PR runs don't
+      # get repository secrets at all, so a login step here would always
+      # fail for a dependency-bump PR regardless of the change being tested.
+      - name: Build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           build-args: |


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary
- `test.yml`'s `build` job tried to log into GCR even though it never pushes (`push: false`) - unnecessary, and Dependabot-triggered runs don't receive repository secrets by design, so this always failed for a dependency-bump PR. Removed the login step entirely; a local build needs no registry credentials.
- `commit-lint` failed on every Dependabot PR because its commit subjects ("Bump alpine from ...") are sentence-case, which fails `subject-case` - not fixable by wording the commitlint config differently. Skipped for `dependabot[bot]`, same as `platformfix/podium`; `pr-lint` still validates its PR titles, and squash-merge uses the PR title/body, not the raw commit message.
- `monitor-k8s-versions.yml` still had a floating `actions/checkout@v4` and no explicit `permissions:` block - missed in #71. Pinned to the same SHA used everywhere else in the repo and scoped permissions to what the workflow's `gh pr create` and git push actually need (`contents: write`, `pull-requests: write`).

## Test plan
- [x] Confirmed the actual failures on open Dependabot PRs #72/#73 before writing the fix (`gh run view --log-failed`): GCR login failed with "Password required", commit-lint failed with `subject-case`
- [x] All three changed workflow files parse (`yq eval`)