### PR TITLE
ci: skip commit-lint by PR author, not triggering actor

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -17,8 +17,13 @@ jobs:
     # Dependabot's own commit messages (e.g. "Bump alpine from 3.23.3 to
     # 3.24.1") fail subject-case regardless of how conventional its PR
     # titles are - those are linted separately by pr-lint, and the squash
-    # merge uses the PR title/body, not the raw commit message.
-    if: github.actor != 'dependabot[bot]'
+    # merge uses the PR title/body, not the raw commit message. Keyed on
+    # the PR's actual author, not github.actor - a manual "update branch"
+    # (e.g. via the API, to satisfy the strict required-status-checks
+    # policy) makes the triggering actor whoever called it, not
+    # dependabot[bot], even though the PR's own commits are still
+    # Dependabot's.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary
- Discovered live on PR #73: manually updating a Dependabot PR's branch (`gh api .../update-branch`, needed to satisfy the ruleset's strict up-to-date requirement) makes the resulting `synchronize` event's `github.actor` the person who called the API, not `dependabot[bot]` - so the actor-based skip added in #76 didn't fire, and commit-lint correctly-but-unhelpfully failed on Dependabot's own commit message again.
- Fixed by keying the skip off `github.event.pull_request.user.login` (the PR's actual author) instead of `github.actor` (whoever triggered this specific event) - correct regardless of who or what causes the branch to sync.
- Same fix applied to `platformfix/podium`, which had the identical bug (not yet hit there, but would have on the exact same trigger).

## Test plan
- [x] Reasoned through the actual GitHub Actions context fields involved (`github.actor` vs `github.event.pull_request.user.login`) rather than guessing