### PR TITLE
fix: upgrade-flux.sh never actually parsed --execute

### DIFF
--- a/scripts/upgrade-flux.sh
+++ b/scripts/upgrade-flux.sh
@@ -223,7 +223,32 @@ Helm stays at ${HELM_VERSION} - flux v${FLUX_VERSION} still pins the same versio
     log "SUCCESS" "Successfully created pull request for Flux upgrade"
 }
 
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
 main() {
+    parse_args "$@"
     check_requirements "git" "gh" "jq" "sed" "awk"
 
     log "INFO" "Fetching latest flux2 release..."


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary
- Caught running the real workflow end-to-end for the first time (dispatched manually to verify #78): the CI run reported "Mode: DRY RUN" even though the workflow passes `--execute`. Root cause: `upgrade-flux.sh` documented `-e`/`--execute` in its `usage()` text (copied from `upgrade-k8s.sh`) but never actually implemented the argument-parsing loop that reads it - `main "$@"` was called, but `main()` never consumed its arguments, so `DRY_RUN` stayed permanently `true` regardless of what was passed.
- Adds the missing `parse_args()`, called at the top of `main()`.

## Test plan
- [x] Isolated test of the parsing logic alone (`DRY_RUN` correctly flips to `false` on `--execute`) before touching the real script
- [x] `shellcheck --severity=error` clean