### PR TITLE
feat: upgrading flux to v2.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Images can be found at [https://eu.gcr.io/swade1987/kubernetes-toolkit](https://
 ### Core Kubernetes Tools
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/) (version passed as build argument)
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) (v5.8.1)
-- [Helm](https://github.com/helm/helm) (v3.19.2) - pinned to flux version
+- [Helm](https://github.com/helm/helm) (v4.2.4) - pinned to flux version
 - [helm-docs](https://github.com/norwoodj/helm-docs)  (v1.14.2)
 
 ### Validation & Testing
@@ -26,7 +26,7 @@ Images can be found at [https://eu.gcr.io/swade1987/kubernetes-toolkit](https://
 - [trivy](https://github.com/aquasecurity/trivy) (v0.72.0)
 
 ### GitOps & Service Mesh
-- [flux](https://github.com/fluxcd/flux2) (v2.7.5)
+- [flux](https://github.com/fluxcd/flux2) (v2.9.5)
 - [flux operator](https://github.com/controlplaneio-fluxcd/flux-operator) (v0.41.0)
 - [istioctl](https://github.com/istio/istio) (v1.28.3)
 

--- a/src/install-dependencies.sh
+++ b/src/install-dependencies.sh
@@ -17,8 +17,7 @@ kustomize version
 HELM_VERSION=4.2.4
 printf "\nDownloading helm %s\n" "${HELM_VERSION}"
 curl -sSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | \
-tar xz && mv linux-amd64/helm /usr/local/bin/helmv3 && rm -rf linux-amd64 && ln -s /usr/local/bin/helmv3 /usr/local/bin/helm
-helmv3 version
+tar xz && mv linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
 helm version
 
 KUBECONFORM=0.7.0

--- a/src/install-dependencies.sh
+++ b/src/install-dependencies.sh
@@ -14,7 +14,7 @@ curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomiz
 tar xz && mv kustomize /usr/local/bin/kustomize
 kustomize version
 
-HELM_VERSION=3.19.2
+HELM_VERSION=4.2.4
 printf "\nDownloading helm %s\n" "${HELM_VERSION}"
 curl -sSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | \
 tar xz && mv linux-amd64/helm /usr/local/bin/helmv3 && rm -rf linux-amd64 && ln -s /usr/local/bin/helmv3 /usr/local/bin/helm
@@ -33,7 +33,7 @@ curl -sL https://github.com/open-policy-agent/conftest/releases/download/v${CONF
 tar xz && mv conftest /usr/local/bin/conftest
 conftest --version
 
-FLUX=2.7.5
+FLUX=2.9.5
 printf "\nDownloading flux %s\n" "${FLUX}"
 curl -sL https://github.com/fluxcd/flux2/releases/download/v${FLUX}/flux_${FLUX}_linux_amd64.tar.gz | \
 tar xz && mv flux /usr/local/bin/flux


### PR DESCRIPTION
Bumps flux from 2.7.5 to 2.9.5. kustomize stays at 5.8.1 - flux v2.9.5 still pins the same version via kustomize-controller v1.9.5.

Also bumps Helm from 3.19.2 to 4.2.4 (helm-controller v1.6.4 pins helm.sh/helm/v4 v4.2.4). Note: this crosses a Helm major version (v3 -> v4) - Helm's CLI surface can differ across majors, so review this one a bit more closely than a routine patch bump.