### PR TITLE
refactor: create upgrade PR commits via the GitHub API, signed

### DIFF
--- a/scripts/lib/signed-pr.sh
+++ b/scripts/lib/signed-pr.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Library         : signed-pr.sh
+# Description     : Pushes an empty branch, then commits the working tree's
+#                    current changes onto it via GitHub's own API, and opens
+#                    a pull request - shared by the upgrade-*.sh scripts.
+###############################################################################
+#
+# A plain "git commit" run in CI produces an unsigned commit (there's no
+# signing key configured on the runner), which fails this repo's
+# "required_signatures" branch ruleset rule and blocks the resulting PR from
+# merging - it doesn't matter that every status check passes. GitHub's
+# createCommitOnBranch GraphQL mutation sidesteps this entirely: it creates
+# the commit server-side, signed by GitHub itself, the same way a squash
+# merge is. The trade-off is that it can only add/replace file *content* at
+# a path (no permission-bit or rename changes) - fine for these scripts,
+# which only ever edit existing text files in place.
+#
+# Requires "log" to already be defined by the sourcing script (all of them
+# define an identical one), and expects to be called with the working tree
+# already containing the uncommitted changes to ship - it reads their
+# current on-disk content directly, not a git diff.
+#
+# Usage: create_signed_pr <branch_name> <commit_headline> <pr_title> <pr_body>
+
+create_signed_pr() {
+    local branch_name="$1" commit_headline="$2" pr_title="$3" pr_body="$4"
+
+    local base_sha repo
+    base_sha="$(git rev-parse HEAD)"
+    repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+
+    log "INFO" "Pushing branch..."
+    git push origin "HEAD:refs/heads/${branch_name}" || { log "ERROR" "Failed to push branch"; exit 1; }
+
+    local changed_files
+    changed_files="$(git diff --name-only HEAD)"
+    if [[ -z "${changed_files}" ]]; then
+        log "ERROR" "No changed files to commit"
+        exit 1
+    fi
+
+    log "INFO" "Building a signed commit via the GitHub API..."
+    local file_changes_json
+    file_changes_json="$(
+        while IFS= read -r f; do
+            jq -n --arg path "$f" --arg contents "$(base64 <"$f" | tr -d '\n')" \
+                '{path: $path, contents: $contents}'
+        done <<<"${changed_files}" | jq -s '{additions: .}'
+    )"
+
+    local payload response commit_oid
+    payload="$(jq -n \
+        --arg repo "$repo" \
+        --arg branch "$branch_name" \
+        --arg headline "$commit_headline" \
+        --arg oid "$base_sha" \
+        --argjson fileChanges "$file_changes_json" \
+        '{
+            query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+            variables: {
+                input: {
+                    branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                    message: { headline: $headline },
+                    expectedHeadOid: $oid,
+                    fileChanges: $fileChanges
+                }
+            }
+        }'
+    )"
+
+    response="$(echo "${payload}" | gh api graphql --input -)"
+    commit_oid="$(echo "${response}" | jq -r '.data.createCommitOnBranch.commit.oid // empty')"
+
+    if [[ -z "${commit_oid}" ]]; then
+        log "ERROR" "Failed to create signed commit: ${response}"
+        exit 1
+    fi
+    log "SUCCESS" "Created signed commit ${commit_oid}"
+
+    log "INFO" "Creating pull request..."
+    gh pr create \
+        --title "$pr_title" \
+        --body "$pr_body" \
+        --base main \
+        --head "$branch_name" || { log "ERROR" "Failed to create PR"; exit 1; }
+
+    log "SUCCESS" "Successfully created pull request"
+}

--- a/scripts/upgrade-flux-operator.sh
+++ b/scripts/upgrade-flux-operator.sh
@@ -19,6 +19,9 @@ set -o pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
 readonly YELLOW='\033[1;33m'
@@ -121,24 +124,8 @@ create_pull_request() {
     local branch_name="flux-operator/upgrade-to-v${TARGET_VERSION}"
     local commit_message="feat: upgrading flux operator to v${TARGET_VERSION}"
 
-    log "INFO" "Creating and checking out branch..."
-    git checkout -b "$branch_name" || { log "ERROR" "Failed to create branch"; exit 1; }
-
-    log "INFO" "Committing changes..."
-    git add .
-    git commit -asm "$commit_message" || { log "ERROR" "Failed to commit changes"; exit 1; }
-
-    log "INFO" "Pushing branch..."
-    git push -u origin "$branch_name" || { log "ERROR" "Failed to push branch"; exit 1; }
-
-    log "INFO" "Creating pull request..."
-    gh pr create \
-        --title "$commit_message" \
-        --body "Bumps the Flux Operator from ${CURRENT_VERSION} to ${TARGET_VERSION}." \
-        --base main \
-        --head "$branch_name" || { log "ERROR" "Failed to create PR"; exit 1; }
-
-    log "SUCCESS" "Successfully created pull request for Flux Operator upgrade"
+    create_signed_pr "$branch_name" "$commit_message" "$commit_message" \
+        "Bumps the Flux Operator from ${CURRENT_VERSION} to ${TARGET_VERSION}."
 }
 
 parse_args() {

--- a/scripts/upgrade-flux.sh
+++ b/scripts/upgrade-flux.sh
@@ -31,6 +31,9 @@ set -o pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
 readonly YELLOW='\033[1;33m'
@@ -182,16 +185,6 @@ create_pull_request() {
     local branch_name="flux/upgrade-to-v${FLUX_VERSION}"
     local commit_message="feat: upgrading flux to v${FLUX_VERSION}"
 
-    log "INFO" "Creating and checking out branch..."
-    git checkout -b "$branch_name" || { log "ERROR" "Failed to create branch"; exit 1; }
-
-    log "INFO" "Committing changes..."
-    git add .
-    git commit -asm "$commit_message" || { log "ERROR" "Failed to commit changes"; exit 1; }
-
-    log "INFO" "Pushing branch..."
-    git push -u origin "$branch_name" || { log "ERROR" "Failed to push branch"; exit 1; }
-
     local body="Bumps flux from ${CURRENT_FLUX} to ${FLUX_VERSION}."
 
     if [[ "${KUSTOMIZE_VERSION}" != "${CURRENT_KUSTOMIZE}" ]]; then
@@ -213,14 +206,7 @@ Also bumps Helm from ${CURRENT_HELM} to ${HELM_VERSION} (helm-controller v${HC_V
 Helm stays at ${HELM_VERSION} - flux v${FLUX_VERSION} still pins the same version via helm-controller v${HC_VERSION}."
     fi
 
-    log "INFO" "Creating pull request..."
-    gh pr create \
-        --title "$commit_message" \
-        --body "$body" \
-        --base main \
-        --head "$branch_name" || { log "ERROR" "Failed to create PR"; exit 1; }
-
-    log "SUCCESS" "Successfully created pull request for Flux upgrade"
+    create_signed_pr "$branch_name" "$commit_message" "$commit_message" "$body"
 }
 
 parse_args() {

--- a/scripts/upgrade-k8s.sh
+++ b/scripts/upgrade-k8s.sh
@@ -20,6 +20,9 @@ set -o pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/lib/signed-pr.sh"
+
 # Color definitions
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
@@ -183,28 +186,8 @@ create_pull_request() {
     local branch_name="${whoami}/upgrade-k8s-to-${KUBERNETES_VERSION}"
     local commit_message="feat: upgrading kubernetes to v${KUBERNETES_VERSION}"
 
-    # Create and checkout branch
-    log "INFO" "Creating and checking out branch..."
-    git checkout -b "$branch_name" || { log "ERROR" "Failed to create branch"; exit 1; }
-
-    # Commit changes
-    log "INFO" "Committing changes..."
-    git add .
-    git commit -asm "$commit_message" || { log "ERROR" "Failed to commit changes"; exit 1; }
-
-    # Push branch
-    log "INFO" "Pushing branch..."
-    git push -u origin "$branch_name" || { log "ERROR" "Failed to push branch"; exit 1; }
-
-    # Create pull request
-    log "INFO" "Creating pull request..."
-    gh pr create \
-        --title "$commit_message" \
-        --body "feat: updating kubernetes version to ${KUBERNETES_VERSION}." \
-        --base main \
-        --head "$branch_name" || { log "ERROR" "Failed to create PR"; exit 1; }
-
-    log "SUCCESS" "Successfully created pull request for Kubernetes version upgrade"
+    create_signed_pr "$branch_name" "$commit_message" "$commit_message" \
+        "feat: updating kubernetes version to ${KUBERNETES_VERSION}."
 }
 
 ###############################################################################


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary
- All three `upgrade-*.sh` scripts (`upgrade-k8s.sh`, `upgrade-flux.sh`, `upgrade-flux-operator.sh`) created their PR commit with a local `git commit`, which produces an unsigned commit when run in CI (no signing key configured on the runner) - failing this repo's `required_signatures` ruleset rule and blocking every automated PR from merging, regardless of how green its checks were. #81 and #83 both hit exactly this wall.
- New shared `scripts/lib/signed-pr.sh` creates the commit via GitHub's `createCommitOnBranch` GraphQL mutation instead - the same mechanism a squash-merge itself uses, so the resulting commit is genuinely signed and Verified by GitHub. It pushes an empty branch at the current HEAD, reads each changed file's current on-disk content, and posts them as the commit's file changes; `gh pr create` is unchanged.
- Extracted as one shared library (not tripled across the three scripts) since it's the one genuinely new, non-trivial piece of logic here - everything else in each script stays as it was.

## Test plan
- [x] Proved the raw GraphQL mutation works and produces a Verified, GitHub-signed commit via a real throwaway branch on this repo before writing any script code around it (not just reading the API docs)
- [x] All three scripts still dry-run correctly with no behavior change (`FLUX target version`, `KUSTOMIZE target version` etc. all report identically to before)
- [x] `shellcheck --severity=error` clean on the library and all three scripts
- [ ] Full live validation: closed #83 (the flux-operator bump PR blocked by the old unsigned-commit path) and will re-dispatch the flux-operator monitor once this merges, to confirm the replacement PR is mergeable end-to-end