### PR TITLE
fix: add the DCO Signed-off-by trailer to API-created commits

### DIFF
--- a/scripts/lib/signed-pr.sh
+++ b/scripts/lib/signed-pr.sh
@@ -50,11 +50,21 @@ create_signed_pr() {
         done <<<"${changed_files}" | jq -s '{additions: .}'
     )"
 
+    # DCO checks the commit *message* for a "Signed-off-by:" trailer - a
+    # completely separate thing from the commit's cryptographic signature,
+    # which this mutation already provides regardless. "git commit -s" used
+    # to add this trailer automatically; creating the commit via the API
+    # instead means it has to be added explicitly here.
+    local signoff_name signoff_email
+    signoff_name="$(git config user.name)"
+    signoff_email="$(git config user.email)"
+
     local payload response commit_oid
     payload="$(jq -n \
         --arg repo "$repo" \
         --arg branch "$branch_name" \
         --arg headline "$commit_headline" \
+        --arg body "Signed-off-by: ${signoff_name} <${signoff_email}>" \
         --arg oid "$base_sha" \
         --argjson fileChanges "$file_changes_json" \
         '{
@@ -62,7 +72,7 @@ create_signed_pr() {
             variables: {
                 input: {
                     branch: { repositoryNameWithOwner: $repo, branchName: $branch },
-                    message: { headline: $headline },
+                    message: { headline: $headline, body: $body },
                     expectedHeadOid: $oid,
                     fileChanges: $fileChanges
                 }


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary
- Found live: the flux-operator PR from the just-merged signed-commit refactor had a genuinely signed commit (`verified: true`) but still failed the `DCO` check. That's a separate requirement checked from the commit *message* - a "Signed-off-by:" trailer, which `git commit -s` used to add automatically and the GraphQL-based commit never included, since `create_signed_pr` only set a `headline`, no `body`.
- Adds the trailer to the commit body, reading the name/email from local git config (already set by each workflow's "Configure Git" step) rather than hardcoding it.

## Test plan
- [x] `shellcheck --severity=error` clean
- [ ] Will re-dispatch the flux-operator monitor once this merges and confirm the resulting PR passes DCO as well as being genuinely signed, before considering the signed-commit mechanism actually done