### PR TITLE
feat: add weekly version-tracking for kubeconform, pluto, istioctl, conftest, helm-docs, shellcheck, trivy

### DIFF
--- a/.github/workflows/monitor-conftest-versions.yml
+++ b/.github/workflows/monitor-conftest-versions.yml
@@ -1,0 +1,50 @@
+name: Monitor uconftest Version
+
+on:
+  schedule:
+    - cron: '0 06 * * 1'  # Weekly, Mondays at 06:00
+  workflow_dispatch:  # Allow manual triggers
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-conftest-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Check for an existing upgrade PR
+        id: check-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading conftest to ")) | .title')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "Found an existing conftest upgrade PR, skipping until it's merged:"
+            echo "$EXISTING_PRS"
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        if: steps.check-prs.outputs.has_pr == 'false'
+        run: |
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
+
+      - name: Run upgrade script
+        if: steps.check-prs.outputs.has_pr == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-conftest.sh
+          ./scripts/upgrade-conftest.sh --execute

--- a/.github/workflows/monitor-helm-docs-versions.yml
+++ b/.github/workflows/monitor-helm-docs-versions.yml
@@ -1,0 +1,50 @@
+name: Monitor uhelm-docs Version
+
+on:
+  schedule:
+    - cron: '0 07 * * 1'  # Weekly, Mondays at 07:00
+  workflow_dispatch:  # Allow manual triggers
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-helm-docs-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Check for an existing upgrade PR
+        id: check-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading helm-docs to ")) | .title')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "Found an existing helm-docs upgrade PR, skipping until it's merged:"
+            echo "$EXISTING_PRS"
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        if: steps.check-prs.outputs.has_pr == 'false'
+        run: |
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
+
+      - name: Run upgrade script
+        if: steps.check-prs.outputs.has_pr == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-helm-docs.sh
+          ./scripts/upgrade-helm-docs.sh --execute

--- a/.github/workflows/monitor-istioctl-versions.yml
+++ b/.github/workflows/monitor-istioctl-versions.yml
@@ -1,0 +1,50 @@
+name: Monitor uistioctl Version
+
+on:
+  schedule:
+    - cron: '0 05 * * 1'  # Weekly, Mondays at 05:00
+  workflow_dispatch:  # Allow manual triggers
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-istioctl-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Check for an existing upgrade PR
+        id: check-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading istioctl to ")) | .title')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "Found an existing istioctl upgrade PR, skipping until it's merged:"
+            echo "$EXISTING_PRS"
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        if: steps.check-prs.outputs.has_pr == 'false'
+        run: |
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
+
+      - name: Run upgrade script
+        if: steps.check-prs.outputs.has_pr == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-istioctl.sh
+          ./scripts/upgrade-istioctl.sh --execute

--- a/.github/workflows/monitor-kubeconform-versions.yml
+++ b/.github/workflows/monitor-kubeconform-versions.yml
@@ -1,0 +1,50 @@
+name: Monitor ukubeconform Version
+
+on:
+  schedule:
+    - cron: '0 03 * * 1'  # Weekly, Mondays at 03:00
+  workflow_dispatch:  # Allow manual triggers
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-kubeconform-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Check for an existing upgrade PR
+        id: check-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading kubeconform to ")) | .title')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "Found an existing kubeconform upgrade PR, skipping until it's merged:"
+            echo "$EXISTING_PRS"
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        if: steps.check-prs.outputs.has_pr == 'false'
+        run: |
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
+
+      - name: Run upgrade script
+        if: steps.check-prs.outputs.has_pr == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-kubeconform.sh
+          ./scripts/upgrade-kubeconform.sh --execute

--- a/.github/workflows/monitor-pluto-versions.yml
+++ b/.github/workflows/monitor-pluto-versions.yml
@@ -1,0 +1,50 @@
+name: Monitor upluto Version
+
+on:
+  schedule:
+    - cron: '0 04 * * 1'  # Weekly, Mondays at 04:00
+  workflow_dispatch:  # Allow manual triggers
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-pluto-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Check for an existing upgrade PR
+        id: check-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading pluto to ")) | .title')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "Found an existing pluto upgrade PR, skipping until it's merged:"
+            echo "$EXISTING_PRS"
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        if: steps.check-prs.outputs.has_pr == 'false'
+        run: |
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
+
+      - name: Run upgrade script
+        if: steps.check-prs.outputs.has_pr == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-pluto.sh
+          ./scripts/upgrade-pluto.sh --execute

--- a/.github/workflows/monitor-shellcheck-versions.yml
+++ b/.github/workflows/monitor-shellcheck-versions.yml
@@ -1,0 +1,50 @@
+name: Monitor ushellcheck Version
+
+on:
+  schedule:
+    - cron: '0 08 * * 1'  # Weekly, Mondays at 08:00
+  workflow_dispatch:  # Allow manual triggers
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-shellcheck-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Check for an existing upgrade PR
+        id: check-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading shellcheck to ")) | .title')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "Found an existing shellcheck upgrade PR, skipping until it's merged:"
+            echo "$EXISTING_PRS"
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        if: steps.check-prs.outputs.has_pr == 'false'
+        run: |
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
+
+      - name: Run upgrade script
+        if: steps.check-prs.outputs.has_pr == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-shellcheck.sh
+          ./scripts/upgrade-shellcheck.sh --execute

--- a/.github/workflows/monitor-trivy-versions.yml
+++ b/.github/workflows/monitor-trivy-versions.yml
@@ -1,0 +1,50 @@
+name: Monitor utrivy Version
+
+on:
+  schedule:
+    - cron: '0 09 * * 1'  # Weekly, Mondays at 09:00
+  workflow_dispatch:  # Allow manual triggers
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-trivy-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Setup GitHub CLI
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Check for an existing upgrade PR
+        id: check-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --json title --jq '.[] | select(.title | contains("upgrading trivy to ")) | .title')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "Found an existing trivy upgrade PR, skipping until it's merged:"
+            echo "$EXISTING_PRS"
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        if: steps.check-prs.outputs.has_pr == 'false'
+        run: |
+          git config user.name "Steve Wade"
+          git config user.email "steven@stevenwade.co.uk"
+
+      - name: Run upgrade script
+        if: steps.check-prs.outputs.has_pr == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          chmod +x ./scripts/upgrade-trivy.sh
+          ./scripts/upgrade-trivy.sh --execute

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 /scripts/upgrade-k8s.sh.log
 /scripts/upgrade-flux.sh.log
 /scripts/upgrade-flux-operator.sh.log
+/scripts/upgrade-kubeconform.sh.log
+/scripts/upgrade-pluto.sh.log
+/scripts/upgrade-istioctl.sh.log
+/scripts/upgrade-conftest.sh.log
+/scripts/upgrade-helm-docs.sh.log
+/scripts/upgrade-shellcheck.sh.log
+/scripts/upgrade-trivy.sh.log

--- a/scripts/lib/simple-version-sync.sh
+++ b/scripts/lib/simple-version-sync.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Library         : simple-version-sync.sh
+# Description     : Checks a tool's latest GitHub release against what's
+#                    currently pinned in src/install-dependencies.sh, and
+#                    (with --execute) opens a PR to bump it via create_signed_pr.
+###############################################################################
+#
+# Shared by the standalone-tool upgrade scripts (kubeconform, pluto,
+# istioctl - each a simple GitHub-releases project with no derivation
+# chain, unlike flux's kustomize/Helm versions). Requires "log",
+# "create_signed_pr", "DRY_RUN" and "INSTALL_SCRIPT" to already be defined
+# by the sourcing script.
+#
+# Usage: sync_simple_tool_version <display name> <owner/repo> <VAR_NAME> <tag prefix, "v" or "">
+# Returns 1 (no error, just "nothing to do") if already in sync.
+
+sync_simple_tool_version() {
+    local display_name="$1" repo="$2" var_name="$3" tag_prefix="$4"
+
+    log "INFO" "Fetching latest ${display_name} release..."
+    local latest_tag target_version current_version
+    latest_tag="$(gh api "repos/${repo}/releases/latest" --jq '.tag_name')"
+    target_version="${latest_tag#"${tag_prefix}"}"
+    current_version="$(grep -E "^${var_name}=" "${INSTALL_SCRIPT}" | head -1 | cut -d= -f2)"
+
+    log "INFO" "${display_name}: current=${current_version} latest=${target_version}"
+
+    if [[ "${target_version}" == "${current_version}" ]]; then
+        log "INFO" "Already on the latest ${display_name} release (${target_version}); nothing to do."
+        return 1
+    fi
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log "INFO" "Would update ${var_name} in ${INSTALL_SCRIPT} to ${target_version}"
+        return 0
+    fi
+
+    sed -i.bak -E "s/^${var_name}=.*/${var_name}=${target_version}/" "${INSTALL_SCRIPT}"
+    rm -f "${INSTALL_SCRIPT}.bak"
+    log "SUCCESS" "Updated ${INSTALL_SCRIPT}"
+
+    local branch_slug
+    branch_slug="$(echo "${var_name}" | tr '[:upper:]' '[:lower:]')"
+    local branch_name="${branch_slug}/upgrade-to-${target_version}"
+    local commit_message="feat: upgrading ${display_name} to ${target_version}"
+
+    create_signed_pr "$branch_name" "$commit_message" "$commit_message" \
+        "Bumps ${display_name} from ${current_version} to ${target_version}."
+}

--- a/scripts/upgrade-conftest.sh
+++ b/scripts/upgrade-conftest.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Script Name     : upgrade-conftest.sh
+# Description     : Creates a pull request to upgrade conftest to its
+#                    latest GitHub release
+###############################################################################
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+# shellcheck source=lib/simple-version-sync.sh
+source "${SCRIPT_DIR}/scripts/lib/simple-version-sync.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+VERBOSE=true
+DRY_RUN=true
+LOG_FILE="${SCRIPT_DIR}/scripts/${SCRIPT_NAME}.log"
+readonly INSTALL_SCRIPT="src/install-dependencies.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Checks conftest's latest GitHub release and (with --execute) opens a
+pull request updating ${INSTALL_SCRIPT} to match.
+
+Options:
+    -h, --help         Show this help message
+    -e, --execute      Execute changes (disabled by default)
+    -l, --log FILE     Log output to specified file
+EOF
+}
+
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+
+    if [[ -n "${LOG_FILE:-}" ]]; then
+        echo "${timestamp} [${level}] ${message}" >> "${LOG_FILE}"
+    fi
+
+    if [[ "${VERBOSE}" == "true" ]] || [[ "${level}" == "ERROR" ]]; then
+        case "${level}" in
+            ERROR)   echo -e "${RED}${timestamp} [${level}] ${message}${NC}" >&2 ;;
+            WARN)    echo -e "${YELLOW}${timestamp} [${level}] ${message}${NC}" ;;
+            SUCCESS) echo -e "${GREEN}${timestamp} [${level}] ${message}${NC}" ;;
+            *)       echo "${timestamp} [${level}] ${message}" ;;
+        esac
+    fi
+}
+
+check_requirements() {
+    local failed=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            log "ERROR" "${cmd} is required but not installed."
+            failed=true
+        fi
+    done
+    [[ "${failed}" == "true" ]] && exit 1
+    return 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    check_requirements "git" "gh" "jq" "sed"
+    sync_simple_tool_version "conftest" "open-policy-agent/conftest" "CONFTEST" "v" || exit 0
+}
+
+parse_args "$@"
+main

--- a/scripts/upgrade-helm-docs.sh
+++ b/scripts/upgrade-helm-docs.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Script Name     : upgrade-helm-docs.sh
+# Description     : Creates a pull request to upgrade helm-docs to its
+#                    latest GitHub release
+###############################################################################
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+# shellcheck source=lib/simple-version-sync.sh
+source "${SCRIPT_DIR}/scripts/lib/simple-version-sync.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+VERBOSE=true
+DRY_RUN=true
+LOG_FILE="${SCRIPT_DIR}/scripts/${SCRIPT_NAME}.log"
+readonly INSTALL_SCRIPT="src/install-dependencies.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Checks helm-docs's latest GitHub release and (with --execute) opens a
+pull request updating ${INSTALL_SCRIPT} to match.
+
+Options:
+    -h, --help         Show this help message
+    -e, --execute      Execute changes (disabled by default)
+    -l, --log FILE     Log output to specified file
+EOF
+}
+
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+
+    if [[ -n "${LOG_FILE:-}" ]]; then
+        echo "${timestamp} [${level}] ${message}" >> "${LOG_FILE}"
+    fi
+
+    if [[ "${VERBOSE}" == "true" ]] || [[ "${level}" == "ERROR" ]]; then
+        case "${level}" in
+            ERROR)   echo -e "${RED}${timestamp} [${level}] ${message}${NC}" >&2 ;;
+            WARN)    echo -e "${YELLOW}${timestamp} [${level}] ${message}${NC}" ;;
+            SUCCESS) echo -e "${GREEN}${timestamp} [${level}] ${message}${NC}" ;;
+            *)       echo "${timestamp} [${level}] ${message}" ;;
+        esac
+    fi
+}
+
+check_requirements() {
+    local failed=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            log "ERROR" "${cmd} is required but not installed."
+            failed=true
+        fi
+    done
+    [[ "${failed}" == "true" ]] && exit 1
+    return 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    check_requirements "git" "gh" "jq" "sed"
+    sync_simple_tool_version "helm-docs" "norwoodj/helm-docs" "HELM_DOCS" "v" || exit 0
+}
+
+parse_args "$@"
+main

--- a/scripts/upgrade-istioctl.sh
+++ b/scripts/upgrade-istioctl.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Script Name     : upgrade-istioctl.sh
+# Description     : Creates a pull request to upgrade istioctl to its
+#                    latest GitHub release
+###############################################################################
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+# shellcheck source=lib/simple-version-sync.sh
+source "${SCRIPT_DIR}/scripts/lib/simple-version-sync.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+VERBOSE=true
+DRY_RUN=true
+LOG_FILE="${SCRIPT_DIR}/scripts/${SCRIPT_NAME}.log"
+readonly INSTALL_SCRIPT="src/install-dependencies.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Checks istioctl's latest GitHub release and (with --execute) opens a
+pull request updating ${INSTALL_SCRIPT} to match.
+
+Options:
+    -h, --help         Show this help message
+    -e, --execute      Execute changes (disabled by default)
+    -l, --log FILE     Log output to specified file
+EOF
+}
+
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+
+    if [[ -n "${LOG_FILE:-}" ]]; then
+        echo "${timestamp} [${level}] ${message}" >> "${LOG_FILE}"
+    fi
+
+    if [[ "${VERBOSE}" == "true" ]] || [[ "${level}" == "ERROR" ]]; then
+        case "${level}" in
+            ERROR)   echo -e "${RED}${timestamp} [${level}] ${message}${NC}" >&2 ;;
+            WARN)    echo -e "${YELLOW}${timestamp} [${level}] ${message}${NC}" ;;
+            SUCCESS) echo -e "${GREEN}${timestamp} [${level}] ${message}${NC}" ;;
+            *)       echo "${timestamp} [${level}] ${message}" ;;
+        esac
+    fi
+}
+
+check_requirements() {
+    local failed=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            log "ERROR" "${cmd} is required but not installed."
+            failed=true
+        fi
+    done
+    [[ "${failed}" == "true" ]] && exit 1
+    return 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    check_requirements "git" "gh" "jq" "sed"
+    sync_simple_tool_version "istioctl" "istio/istio" "ISTIOCTL" "" || exit 0
+}
+
+parse_args "$@"
+main

--- a/scripts/upgrade-kubeconform.sh
+++ b/scripts/upgrade-kubeconform.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Script Name     : upgrade-kubeconform.sh
+# Description     : Creates a pull request to upgrade kubeconform to its
+#                    latest GitHub release
+###############################################################################
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+# shellcheck source=lib/simple-version-sync.sh
+source "${SCRIPT_DIR}/scripts/lib/simple-version-sync.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+VERBOSE=true
+DRY_RUN=true
+LOG_FILE="${SCRIPT_DIR}/scripts/${SCRIPT_NAME}.log"
+readonly INSTALL_SCRIPT="src/install-dependencies.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Checks kubeconform's latest GitHub release and (with --execute) opens a
+pull request updating ${INSTALL_SCRIPT} to match.
+
+Options:
+    -h, --help         Show this help message
+    -e, --execute      Execute changes (disabled by default)
+    -l, --log FILE     Log output to specified file
+EOF
+}
+
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+
+    if [[ -n "${LOG_FILE:-}" ]]; then
+        echo "${timestamp} [${level}] ${message}" >> "${LOG_FILE}"
+    fi
+
+    if [[ "${VERBOSE}" == "true" ]] || [[ "${level}" == "ERROR" ]]; then
+        case "${level}" in
+            ERROR)   echo -e "${RED}${timestamp} [${level}] ${message}${NC}" >&2 ;;
+            WARN)    echo -e "${YELLOW}${timestamp} [${level}] ${message}${NC}" ;;
+            SUCCESS) echo -e "${GREEN}${timestamp} [${level}] ${message}${NC}" ;;
+            *)       echo "${timestamp} [${level}] ${message}" ;;
+        esac
+    fi
+}
+
+check_requirements() {
+    local failed=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            log "ERROR" "${cmd} is required but not installed."
+            failed=true
+        fi
+    done
+    [[ "${failed}" == "true" ]] && exit 1
+    return 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    check_requirements "git" "gh" "jq" "sed"
+    sync_simple_tool_version "kubeconform" "yannh/kubeconform" "KUBECONFORM" "v" || exit 0
+}
+
+parse_args "$@"
+main

--- a/scripts/upgrade-pluto.sh
+++ b/scripts/upgrade-pluto.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Script Name     : upgrade-pluto.sh
+# Description     : Creates a pull request to upgrade pluto to its
+#                    latest GitHub release
+###############################################################################
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+# shellcheck source=lib/simple-version-sync.sh
+source "${SCRIPT_DIR}/scripts/lib/simple-version-sync.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+VERBOSE=true
+DRY_RUN=true
+LOG_FILE="${SCRIPT_DIR}/scripts/${SCRIPT_NAME}.log"
+readonly INSTALL_SCRIPT="src/install-dependencies.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Checks pluto's latest GitHub release and (with --execute) opens a
+pull request updating ${INSTALL_SCRIPT} to match.
+
+Options:
+    -h, --help         Show this help message
+    -e, --execute      Execute changes (disabled by default)
+    -l, --log FILE     Log output to specified file
+EOF
+}
+
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+
+    if [[ -n "${LOG_FILE:-}" ]]; then
+        echo "${timestamp} [${level}] ${message}" >> "${LOG_FILE}"
+    fi
+
+    if [[ "${VERBOSE}" == "true" ]] || [[ "${level}" == "ERROR" ]]; then
+        case "${level}" in
+            ERROR)   echo -e "${RED}${timestamp} [${level}] ${message}${NC}" >&2 ;;
+            WARN)    echo -e "${YELLOW}${timestamp} [${level}] ${message}${NC}" ;;
+            SUCCESS) echo -e "${GREEN}${timestamp} [${level}] ${message}${NC}" ;;
+            *)       echo "${timestamp} [${level}] ${message}" ;;
+        esac
+    fi
+}
+
+check_requirements() {
+    local failed=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            log "ERROR" "${cmd} is required but not installed."
+            failed=true
+        fi
+    done
+    [[ "${failed}" == "true" ]] && exit 1
+    return 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    check_requirements "git" "gh" "jq" "sed"
+    sync_simple_tool_version "pluto" "FairwindsOps/pluto" "PLUTO" "v" || exit 0
+}
+
+parse_args "$@"
+main

--- a/scripts/upgrade-shellcheck.sh
+++ b/scripts/upgrade-shellcheck.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Script Name     : upgrade-shellcheck.sh
+# Description     : Creates a pull request to upgrade shellcheck to its
+#                    latest GitHub release
+###############################################################################
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+# shellcheck source=lib/simple-version-sync.sh
+source "${SCRIPT_DIR}/scripts/lib/simple-version-sync.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+VERBOSE=true
+DRY_RUN=true
+LOG_FILE="${SCRIPT_DIR}/scripts/${SCRIPT_NAME}.log"
+readonly INSTALL_SCRIPT="src/install-dependencies.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Checks shellcheck's latest GitHub release and (with --execute) opens a
+pull request updating ${INSTALL_SCRIPT} to match.
+
+Options:
+    -h, --help         Show this help message
+    -e, --execute      Execute changes (disabled by default)
+    -l, --log FILE     Log output to specified file
+EOF
+}
+
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+
+    if [[ -n "${LOG_FILE:-}" ]]; then
+        echo "${timestamp} [${level}] ${message}" >> "${LOG_FILE}"
+    fi
+
+    if [[ "${VERBOSE}" == "true" ]] || [[ "${level}" == "ERROR" ]]; then
+        case "${level}" in
+            ERROR)   echo -e "${RED}${timestamp} [${level}] ${message}${NC}" >&2 ;;
+            WARN)    echo -e "${YELLOW}${timestamp} [${level}] ${message}${NC}" ;;
+            SUCCESS) echo -e "${GREEN}${timestamp} [${level}] ${message}${NC}" ;;
+            *)       echo "${timestamp} [${level}] ${message}" ;;
+        esac
+    fi
+}
+
+check_requirements() {
+    local failed=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            log "ERROR" "${cmd} is required but not installed."
+            failed=true
+        fi
+    done
+    [[ "${failed}" == "true" ]] && exit 1
+    return 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    check_requirements "git" "gh" "jq" "sed"
+    sync_simple_tool_version "shellcheck" "koalaman/shellcheck" "SHELLCHECK" "" || exit 0
+}
+
+parse_args "$@"
+main

--- a/scripts/upgrade-trivy.sh
+++ b/scripts/upgrade-trivy.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Script Name     : upgrade-trivy.sh
+# Description     : Creates a pull request to upgrade trivy to its
+#                    latest GitHub release
+###############################################################################
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=lib/signed-pr.sh
+source "${SCRIPT_DIR}/scripts/lib/signed-pr.sh"
+# shellcheck source=lib/simple-version-sync.sh
+source "${SCRIPT_DIR}/scripts/lib/simple-version-sync.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+VERBOSE=true
+DRY_RUN=true
+LOG_FILE="${SCRIPT_DIR}/scripts/${SCRIPT_NAME}.log"
+readonly INSTALL_SCRIPT="src/install-dependencies.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Checks trivy's latest GitHub release and (with --execute) opens a
+pull request updating ${INSTALL_SCRIPT} to match.
+
+Options:
+    -h, --help         Show this help message
+    -e, --execute      Execute changes (disabled by default)
+    -l, --log FILE     Log output to specified file
+EOF
+}
+
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp="$(date +'%Y-%m-%d %H:%M:%S')"
+
+    if [[ -n "${LOG_FILE:-}" ]]; then
+        echo "${timestamp} [${level}] ${message}" >> "${LOG_FILE}"
+    fi
+
+    if [[ "${VERBOSE}" == "true" ]] || [[ "${level}" == "ERROR" ]]; then
+        case "${level}" in
+            ERROR)   echo -e "${RED}${timestamp} [${level}] ${message}${NC}" >&2 ;;
+            WARN)    echo -e "${YELLOW}${timestamp} [${level}] ${message}${NC}" ;;
+            SUCCESS) echo -e "${GREEN}${timestamp} [${level}] ${message}${NC}" ;;
+            *)       echo "${timestamp} [${level}] ${message}" ;;
+        esac
+    fi
+}
+
+check_requirements() {
+    local failed=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            log "ERROR" "${cmd} is required but not installed."
+            failed=true
+        fi
+    done
+    [[ "${failed}" == "true" ]] && exit 1
+    return 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -e|--execute)
+                DRY_RUN=false
+                shift
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            *)
+                log "ERROR" "Unexpected argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    check_requirements "git" "gh" "jq" "sed"
+    sync_simple_tool_version "trivy" "aquasecurity/trivy" "TRIVY" "v" || exit 0
+}
+
+parse_args "$@"
+main


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Extends the flux/flux-operator weekly version-tracking pattern to the remaining standalone tools in `src/install-dependencies.sh` that are simple GitHub-releases projects with no derivation chain.

Deliberately **excludes yq and jq** — both are used as scripting dependencies elsewhere in this repo's own automation (JSON/YAML parsing), so an unattended version bump risks a silent breaking change cascading into other CI. Those two stay manually managed.

## What's new

- `scripts/lib/simple-version-sync.sh` — shared library extracted from the per-tool logic, used by all seven new wrapper scripts (and any future simple GitHub-releases tool) to avoid duplicating the same current-vs-latest-version diff/PR logic seven times over.
- `scripts/upgrade-{kubeconform,pluto,istioctl,conftest,helm-docs,shellcheck,trivy}.sh` — thin wrappers calling the shared library, following the existing `upgrade-flux.sh` / `upgrade-flux-operator.sh` structure (`log()`, `check_requirements()`, `parse_args()`, `--execute`/dry-run).
- `.github/workflows/monitor-{tool}-versions.yml` — weekly Monday cron jobs (staggered hourly, 03:00–09:00, continuing on from flux at 01:00 and flux-operator at 02:00), each checking for an existing open upgrade PR before running, matching the `monitor-flux-versions.yml` pattern exactly.
- `.gitignore` — added the seven new `*.sh.log` dry-run log paths, matching the existing entries for flux/flux-operator/k8s.

## Verification

- Shellcheck clean at `severity: error` (the project's CI threshold) — matches the existing warning/info-only noise already present in `upgrade-flux.sh` (SC2155/SC1091), nothing new.
- `actionlint` clean on all seven new workflow files.
- Dry-ran every new script against the live GitHub API: correctly detected pending upgrades for kubeconform, pluto, istioctl, conftest, shellcheck, and trivy, and correctly detected helm-docs as already current (no PR opened).
- `src/install-dependencies.sh` is unmodified by this PR — only the automation is being added, actual version bumps land as separate PRs from the scheduled workflows.