### PR TITLE
fix: correct broken workflow names from BSD sed incompatibility

### DIFF
--- a/.github/workflows/monitor-conftest-versions.yml
+++ b/.github/workflows/monitor-conftest-versions.yml
@@ -1,4 +1,4 @@
-name: Monitor uconftest Version
+name: Monitor Conftest Version
 
 on:
   schedule:

--- a/.github/workflows/monitor-helm-docs-versions.yml
+++ b/.github/workflows/monitor-helm-docs-versions.yml
@@ -1,4 +1,4 @@
-name: Monitor uhelm-docs Version
+name: Monitor Helm-docs Version
 
 on:
   schedule:

--- a/.github/workflows/monitor-istioctl-versions.yml
+++ b/.github/workflows/monitor-istioctl-versions.yml
@@ -1,4 +1,4 @@
-name: Monitor uistioctl Version
+name: Monitor Istioctl Version
 
 on:
   schedule:

--- a/.github/workflows/monitor-kubeconform-versions.yml
+++ b/.github/workflows/monitor-kubeconform-versions.yml
@@ -1,4 +1,4 @@
-name: Monitor ukubeconform Version
+name: Monitor Kubeconform Version
 
 on:
   schedule:

--- a/.github/workflows/monitor-pluto-versions.yml
+++ b/.github/workflows/monitor-pluto-versions.yml
@@ -1,4 +1,4 @@
-name: Monitor upluto Version
+name: Monitor Pluto Version
 
 on:
   schedule:

--- a/.github/workflows/monitor-shellcheck-versions.yml
+++ b/.github/workflows/monitor-shellcheck-versions.yml
@@ -1,4 +1,4 @@
-name: Monitor ushellcheck Version
+name: Monitor Shellcheck Version
 
 on:
   schedule:

--- a/.github/workflows/monitor-trivy-versions.yml
+++ b/.github/workflows/monitor-trivy-versions.yml
@@ -1,4 +1,4 @@
-name: Monitor utrivy Version
+name: Monitor Trivy Version
 
 on:
   schedule:


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Follow-up to #88. The generator script used `sed 's/.*/\u&/'` to title-case each tool's display name for the `name:` field, but that `\u` escape is a GNU sed extension — BSD/macOS sed (what generated these files) doesn't support it and instead prints a literal `u`. Every one of the seven new workflow names came out wrong, e.g. `Monitor ukubeconform Version` instead of `Monitor Kubeconform Version`.

Fixes all seven: kubeconform, pluto, istioctl, conftest, helm-docs, shellcheck, trivy. No other content changed — verified via diff that only the `name:` line moved in each file.