### PR TITLE
fix: sync README.md tool versions alongside install-dependencies.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,27 @@ Images can be found at [https://eu.gcr.io/swade1987/kubernetes-toolkit](https://
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/) (version passed as build argument)
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) (v5.8.1)
 - [Helm](https://github.com/helm/helm) (v4.2.4) - pinned to flux version
-- [helm-docs](https://github.com/norwoodj/helm-docs)  (v1.14.2)
+- [helm-docs](https://github.com/norwoodj/helm-docs) (v1.14.2)
 
 ### Validation & Testing
-- [kubeconform](https://github.com/yannh/kubeconform) (v0.7.0)
-- [conftest](https://github.com/open-policy-agent/conftest) (v0.66.0)
-- [pluto](https://github.com/FairwindsOps/pluto) (v5.22.7)
+- [kubeconform](https://github.com/yannh/kubeconform) (v0.8.0)
+- [conftest](https://github.com/open-policy-agent/conftest) (v0.69.0)
+- [pluto](https://github.com/FairwindsOps/pluto) (v5.24.3)
 
 ### Container Tools
-- [trivy](https://github.com/aquasecurity/trivy) (v0.72.0)
+- [trivy](https://github.com/aquasecurity/trivy) (v0.74.0)
 
 ### GitOps & Service Mesh
 - [flux](https://github.com/fluxcd/flux2) (v2.9.5)
 - [flux operator](https://github.com/controlplaneio-fluxcd/flux-operator) (v0.59.0)
-- [istioctl](https://github.com/istio/istio) (v1.28.3)
+- [istioctl](https://github.com/istio/istio) (v1.31.0)
 
 ### Configuration Processing
 - [yq](https://github.com/mikefarah/yq) (v4.44.3)
 - [jq](https://github.com/stedolan/jq) (v1.7.1)
 
 ### Development & Linting Tools
-- [shellcheck](https://github.com/koalaman/shellcheck) (v0.10.0)
+- [shellcheck](https://github.com/koalaman/shellcheck) (v0.11.0)
 - [jsonlint](https://github.com/zaach/jsonlint) (v1.6.3)
 
 ### Schema Support

--- a/scripts/lib/simple-version-sync.sh
+++ b/scripts/lib/simple-version-sync.sh
@@ -11,13 +11,17 @@
 # istioctl - each a simple GitHub-releases project with no derivation
 # chain, unlike flux's kustomize/Helm versions). Requires "log",
 # "create_signed_pr", "DRY_RUN" and "INSTALL_SCRIPT" to already be defined
-# by the sourcing script.
+# by the sourcing script. Also updates README.md's tool table, matching
+# upgrade-flux.sh / upgrade-flux-operator.sh - the README's markdown link
+# for the tool must read "[<display name>](https://github.com/<repo>) (vX.Y.Z)"
+# with the repo exactly matching the <owner/repo> argument.
 #
 # Usage: sync_simple_tool_version <display name> <owner/repo> <VAR_NAME> <tag prefix, "v" or "">
 # Returns 1 (no error, just "nothing to do") if already in sync.
 
 sync_simple_tool_version() {
     local display_name="$1" repo="$2" var_name="$3" tag_prefix="$4"
+    local readme="README.md"
 
     log "INFO" "Fetching latest ${display_name} release..."
     local latest_tag target_version current_version
@@ -34,12 +38,19 @@ sync_simple_tool_version() {
 
     if [[ "${DRY_RUN}" == "true" ]]; then
         log "INFO" "Would update ${var_name} in ${INSTALL_SCRIPT} to ${target_version}"
+        log "INFO" "Would update ${display_name} entry in ${readme}"
         return 0
     fi
 
     sed -i.bak -E "s/^${var_name}=.*/${var_name}=${target_version}/" "${INSTALL_SCRIPT}"
     rm -f "${INSTALL_SCRIPT}.bak"
     log "SUCCESS" "Updated ${INSTALL_SCRIPT}"
+
+    local readme_version="${target_version}"
+    [[ "${readme_version}" != v* ]] && readme_version="v${readme_version}"
+    sed -i.bak -E "s|(\[${display_name}\]\(https://github.com/${repo}\))[[:space:]]+\(v[0-9.]+\)|\1 (${readme_version})|" "${readme}"
+    rm -f "${readme}.bak"
+    log "SUCCESS" "Updated ${readme}"
 
     local branch_slug
     branch_slug="$(echo "${var_name}" | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Root cause of the stale README versions after the last batch of upgrade PRs (#90-#95): `upgrade-flux.sh` and `upgrade-flux-operator.sh` both already update `README.md`'s version table alongside `src/install-dependencies.sh`, but the shared `scripts/lib/simple-version-sync.sh` library used by the seven newer tool scripts only touched `install-dependencies.sh`. Every future automated bump for kubeconform, pluto, istioctl, conftest, helm-docs, shellcheck, and trivy would have kept silently drifting the README out of sync.

## Fix

- `scripts/lib/simple-version-sync.sh` now also updates the tool's `[name](url) (vX.Y.Z)` line in `README.md`, matching the pattern already used by `upgrade-flux.sh`/`upgrade-flux-operator.sh`. The anchor is derived from the same `<owner/repo>` argument already passed in, so no extra per-tool parameter was needed.
- `README.md` — caught up the six versions that actually landed from #90-#95 (kubeconform 0.8.0, conftest 0.69.0, pluto 5.24.3, trivy 0.74.0, istioctl 1.31.0, shellcheck v0.11.0). Also normalized a pre-existing double-space typo on the helm-docs line while touching that section.

## Verification

- Shellcheck clean.
- Ran the new sed pattern against a scratch copy of `README.md` for all seven tools with synthetic version bumps — every line updated correctly.
- Dry-ran all seven live scripts; all report "already on the latest" (expected, since #90-#95 just merged), so the new README path isn't exercised end-to-end by this PR — the scratch-copy test above is what proves the regex itself is correct. It will exercise for real on the next actual upstream release.
- Cross-checked README.md against `install-dependencies.sh` line by line post-edit; all seven now match exactly.